### PR TITLE
Fix alt-text url parameter

### DIFF
--- a/bin/api.ts
+++ b/bin/api.ts
@@ -339,10 +339,10 @@ class APITester {
     // Test AI alt-text without auth (should return 401)
     results.push(await this.makeRequest("/api/ai/alt", "GET", undefined, undefined, {}, 401))
 
-    // Test AI alt-text GET with image parameter (should return 200 or 400)
+    // Test AI alt-text GET with url parameter (should return 200 or 400)
     results.push(
       await this.makeRequest(
-        "/api/ai/alt?image=https://example.com/image.jpg",
+        "/api/ai/alt?url=https://example.com/image.jpg",
         "GET",
         this.tokens.get("ai"),
         undefined,
@@ -367,13 +367,13 @@ class APITester {
 
     // Test AI alt-text with invalid URL (should return 400)
     results.push(
-      await this.makeRequest("/api/ai/alt?image=invalid-url", "GET", this.tokens.get("ai"), undefined, {}, 400)
+      await this.makeRequest("/api/ai/alt?url=invalid-url", "GET", this.tokens.get("ai"), undefined, {}, 400)
     )
 
     // Test AI alt-text with wrong permission token (should return 401)
     results.push(
       await this.makeRequest(
-        "/api/ai/alt?image=https://example.com/image.jpg",
+        "/api/ai/alt?url=https://example.com/image.jpg",
         "GET",
         this.tokens.get("metrics"),
         undefined,

--- a/server/api/ai/alt.get.ts
+++ b/server/api/ai/alt.get.ts
@@ -12,10 +12,10 @@ export default defineEventHandler(async (event) => {
     const auth = await requireAIAuth(event, "alt")
 
     const query = getQuery(event)
-    const imageUrl = query.image as string
+    const imageUrl = query.url as string
 
     if (!imageUrl) {
-      throw createApiError(400, "Image URL is required (image parameter)")
+      throw createApiError(400, "Image URL is required (url parameter)")
     }
 
     // Get environment bindings using helper


### PR DESCRIPTION
## Summary
- read `url` query param in alt text GET API
- update CLI tests to send `url` instead of `image`

## Testing
- `bun run test`


------
https://chatgpt.com/codex/tasks/task_e_6845b30c1ba08332907ccf78ee4859b8

## Summary by Sourcery

Fix the AI alt-text GET endpoint to use the correct `url` query parameter and update related tests

Bug Fixes:
- Fix AI alt-text GET handler to read the `url` parameter instead of `image` and update its error message

Tests:
- Update CLI/API tests to send `url` instead of `image` in alt-text GET requests