### PR TITLE
Update README export pattern note

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,10 +418,10 @@ redirect:
 - **Anchor Processing**: Properly handles YAML anchors and excludes `_anchors` section
 - **Schema Conversion**: Converts nested YAML back to flat KV keys automatically
 
-**Export Patterns (new structured hierarchy):**
+**Export Patterns (hierarchical YAML, flat KV keys like `metrics:ok` and `redirect:gh`):**
 
-- `metrics` - Single structured JSON object with all metrics
-- `redirect` - Single JSON object with all redirect mappings
+- `metrics` - YAML tree of metrics, stored using keys like `metrics:ok`
+- `redirect` - YAML tree of redirect mappings, stored using keys like `redirect:gh`
 - `dashboard:*` - Dashboard cache data
 - `routeros:*` - RouterOS cache (legacy, may be removed)
 


### PR DESCRIPTION
## Summary
- clarify that export patterns use hierarchical YAML but KV keys are flat

## Testing
- `bun run test`

------
https://chatgpt.com/codex/tasks/task_e_6845b49e143083329ec52d8b64190f66

## Summary by Sourcery

Clarify the export patterns section in the README to emphasize that data is stored as a hierarchical YAML tree but keyed in a flat KV format, with examples like `metrics:ok` and `redirect:gh`.

Documentation:
- Update export patterns heading to mention hierarchical YAML with flat KV keys
- Revise `metrics` and `redirect` entries to describe YAML tree storage with keys like `metrics:ok` and `redirect:gh`