### PR TITLE
Improve alt-text handler with base64 validation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -309,7 +309,9 @@ Nuxt 3 + Cloudflare Workers REST API platform. Migrated from simple Worker to en
 ## Key APIs
 
 **Core**: `/api/internal/health`, `/api/internal/ping`, `/api/internal/auth`, `/api/internal/metrics` (json/yaml/prometheus)
-**AI**: `/api/ai/alt` (GET url param, POST body/upload)
+**AI**: `/api/ai/alt` (GET url param, POST raw base64)
+  - **BREAKING CHANGE**: POST handler no longer accepts data URLs. Supply raw base64 only.
+  - Images limited to 4MB after decoding
 **Tokens**: `/api/tokens/{uuid}/usage`, `/api/tokens/{uuid}/revoke`
 **Redirects**: `/go/{slug}` (gh/tw/li)
 

--- a/README.md
+++ b/README.md
@@ -59,12 +59,13 @@ bun jwt create --interactive
 
 **Permission Hierarchy**: `api:metrics` → `api` → `admin` → `*` (each level inherits access to lower levels)
 
-### 🤖 AI Integration (Now With Real AI Magic!)
+-### 🤖 AI Integration (Now With Real AI Magic!)
 
-- Alt-text generation for images (URL or file upload) using Cloudflare AI
+- Alt-text generation for images (URL or raw base64) using Cloudflare AI
 - Powered by `@cf/llava-hf/llava-1.5-7b-hf` model (because we don't mess around with fake AI)
 - Because accessibility matters, even for personal sites that are way too complicated
-- File size validation and proper error handling (up to 10MB images)
+- File size validation and proper error handling (up to 4MB images)
+- **🚨 BREAKING CHANGE**: POST body now accepts raw base64 only (no data URLs)
 - Consistent authentication and response formatting across both GET and POST endpoints
 
 ### 📊 KV Metrics Which Would Make Google Jealous
@@ -225,15 +226,10 @@ Generate alt-text for images. Because accessibility is cooler than avocado toast
 # Via URL parameter (the lazy way)
 curl -H "Authorization: Bearer <token>" "http://localhost:3000/api/ai/alt?url=https://example.com/image.jpg"
 
-# Via POST body (the proper way)
+# Via POST body (raw base64)
 curl -X POST -H "Authorization: Bearer <token>" \
   -H "Content-Type: application/json" \
-  -d '{"url": "https://example.com/image.jpg"}' \
-  http://localhost:3000/api/ai/alt
-
-# File upload (for when you're feeling fancy)
-curl -X POST -H "Authorization: Bearer <token>" \
-  -F "file=@image.jpg" \
+  -d '{"image": "<base64-image>"}' \
   http://localhost:3000/api/ai/alt
 ```
 

--- a/biome.json
+++ b/biome.json
@@ -13,6 +13,7 @@
       "components.d.ts",
       "auto-imports.d.ts",
       ".nuxt",
+      "wasm",
       ".codacy",
       ".output"
     ]

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "cloudflare": "4.3.0",
     "date-fns": "4.1.0",
     "fast-xml-parser": "5.2.4",
+    "file-type": "^20.1.0",
     "jose": "6.0.11",
     "js-yaml": "4.1.0",
     "jsonc-parser": "3.3.1",

--- a/server/utils/schemas.ts
+++ b/server/utils/schemas.ts
@@ -212,7 +212,12 @@ export const CreateRedirectSchema = z.object({
 export const AiAltTextRequestSchema = z
   .object({
     url: z.string().url().optional(),
-    image: z.string().optional() // base64 encoded image
+    image: z
+      .string()
+      .refine((val) => !val.startsWith("data:"), {
+        message: "Image must be raw base64 without data URL"
+      })
+      .optional() // base64 encoded image
   })
   .refine((data) => data.url || data.image, {
     message: "Either url or image must be provided"

--- a/test/image-validation.test.ts
+++ b/test/image-validation.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest"
+import { validateBase64Image } from "~/server/utils/validation"
+
+const smallPngBase64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M/wHwAE/AO/lZy6hAAAAABJRU5ErkJggg=="
+
+const textBase64 = Buffer.from("hello world").toString("base64")
+
+describe("validateBase64Image", () => {
+  it("accepts valid base64 image", async () => {
+    const buf = await validateBase64Image(smallPngBase64)
+    expect(buf).toBeInstanceOf(Buffer)
+    expect(buf.length).toBeGreaterThan(0)
+  })
+
+  it("rejects invalid base64", async () => {
+    await expect(validateBase64Image("notbase64" as string)).rejects.toThrow()
+  })
+
+  it("rejects non-image data", async () => {
+    await expect(validateBase64Image(textBase64)).rejects.toThrow()
+  })
+})


### PR DESCRIPTION
## Summary
- validate base64 uploads using `file-type`
- restrict POST alt-text endpoint to raw base64 data
- document the breaking change in README and CLAUDE
- ignore `wasm` folder for linting
- add tests for base64 image validation

## Testing
- `bun run lint` *(fails: fetch failed)*
- `bun run typecheck`
- `bun run test`
- `bun run check` *(fails: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6845b3a888c08332b2ee3c3a6233d01e

## Summary by Sourcery

Enhance the alt-text endpoint by enforcing strict base64 and URL image validation, restricting POST uploads to raw base64 data, and updating documentation and tests to reflect the breaking changes and new size limits

New Features:
- Add validateBase64Image utility to decode and verify raw base64-encoded images
- Restrict POST /api/ai/alt endpoint to accept only raw base64 image data

Enhancements:
- Replace inline image fetching logic with validateImageURL and validateBase64Image helpers
- Enforce file-type based MIME validation and size limits for both URL and base64 inputs

Documentation:
- Document the breaking change for raw base64 POST bodies and 4MB image size limit in README and CLAUDE

Tests:
- Add tests for base64 image validation covering valid images, invalid base64 strings, and non-image data