### PR TITLE
Fix docs to emphasize flat KV schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ bun jwt create --interactive
 
 ### 💾 KV Storage Management (The Crown Jewel)
 
-**🚨 BREAKING CHANGE**: Enhanced YAML support with anchors and structured schema!
+**🚨 BREAKING CHANGE**: Enhanced YAML support with anchors and a hierarchical layout for readability while storing values as flat KV keys.
 
 - Complete export/import system with structured YAML
 - YAML anchor/reference support for DRY configuration management
@@ -365,7 +365,7 @@ bun run kv --local wipe              # Wipe local dev storage (safe!)
 **YAML All The Things! (Now With More Structure!):**
 
 The new YAML export/import system is even better:
-- **Human-Readable**: Structured hierarchical configuration files
+- **Human-Readable**: Hierarchical YAML for readability, automatically converted to flat KV keys
 - **Git-Friendly**: Proper diff support and version control
 - **Anchor Support**: YAML anchors and references for DRY configuration
 - **Integer Handling**: Numbers exported as integers, not strings
@@ -655,7 +655,7 @@ metrics:redirect:blog:error = "2"
 
 **Trade-offs**: Simple flat keys prioritize code maintainability over query performance. Multiple KV lookups required for dashboard aggregation.
 
-> **TODO**: Add metrics to measure KV lookup timing impacts. Track time taken for each operation and all operations. Quantify the performance cost of flat key structure vs structured JSON approach.
+> **TODO**: Add metrics to measure KV lookup timing impacts. Track time taken for each operation and all operations. Quantify any performance difference between the flat key structure and the previous hierarchical JSON schema.
 
 ### Current Architecture Benefits
 

--- a/wasm/reader/INTEGRATION.md
+++ b/wasm/reader/INTEGRATION.md
@@ -306,7 +306,7 @@ export async function updateReaderMetrics(
 ) {
   const kv = getKVNamespace()
   
-  // Update hierarchical metrics following existing pattern
+  // Update metrics using the flat key/value approach
   await Promise.all([
     updateResourceMetrics(kv, 'reader', statusCode),
     updateVisitorMetrics(kv, 'reader', ip),


### PR DESCRIPTION
## Summary
- clarify README to describe flat key/value storage
- reword TODO to compare against old hierarchical JSON structure
- note YAML export/import uses hierarchical layout but stays flat in KV
- update WASM integration guide to mention the flat key/value approach

## Testing
- `bun run test`

------
https://chatgpt.com/codex/tasks/task_e_6845bce54adc8332af047108d4cd3392

## Summary by Sourcery

Clarify in documentation that despite using hierarchical YAML for readability, all values are stored in a flat key/value schema and update related examples and TODOs accordingly.

Documentation:
- Clarify breaking change note in README to highlight that values are stored as flat KV keys despite hierarchical YAML layout
- Update YAML export/import description in README to emphasize conversion to flat KV keys for readability
- Reword TODO in README to compare performance between the flat KV schema and the previous hierarchical JSON approach
- Update WASM integration guide to reference the flat key/value approach when updating metrics