### PR TITLE
Add environment utils tests

### DIFF
--- a/test/environment-utils.test.ts
+++ b/test/environment-utils.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest"
+import {
+  getEnvironmentConfig,
+  getEnvironmentVariable,
+  isDevelopment,
+  isProduction
+} from "~/server/utils/environment"
+
+let originalNodeEnv: string | undefined
+let originalCfEnv: string | undefined
+let originalTestVar: string | undefined
+
+beforeEach(() => {
+  originalNodeEnv = process.env.NODE_ENV
+  originalCfEnv = process.env.CLOUDFLARE_ENVIRONMENT
+  originalTestVar = process.env.TEST_VAR
+})
+
+afterEach(() => {
+  if (originalNodeEnv !== undefined) {
+    process.env.NODE_ENV = originalNodeEnv
+  } else {
+    process.env.NODE_ENV = undefined as unknown as string
+  }
+
+  if (originalCfEnv !== undefined) {
+    process.env.CLOUDFLARE_ENVIRONMENT = originalCfEnv
+  } else {
+    process.env.CLOUDFLARE_ENVIRONMENT = undefined as unknown as string
+  }
+
+  if (originalTestVar !== undefined) {
+    process.env.TEST_VAR = originalTestVar
+  } else {
+    delete (process.env as Record<string, string>).TEST_VAR
+  }
+})
+
+describe("getEnvironmentConfig", () => {
+  it("returns development config when NODE_ENV is development", () => {
+    process.env.NODE_ENV = "development"
+    process.env.CLOUDFLARE_ENVIRONMENT = undefined as unknown as string
+    const config = getEnvironmentConfig()
+    expect(config.environment).toBe("development")
+    expect(config.allowMockData).toBe(true)
+    expect(config.gracefulDegradation).toBe(true)
+  })
+
+  it("returns production config when NODE_ENV is production", () => {
+    process.env.NODE_ENV = "production"
+    process.env.CLOUDFLARE_ENVIRONMENT = undefined as unknown as string
+    const config = getEnvironmentConfig()
+    expect(config.environment).toBe("production")
+    expect(config.allowMockData).toBe(false)
+    expect(config.gracefulDegradation).toBe(false)
+  })
+
+  it("returns production when CLOUDFLARE_ENVIRONMENT is production", () => {
+    process.env.NODE_ENV = "development"
+    process.env.CLOUDFLARE_ENVIRONMENT = "production"
+    const config = getEnvironmentConfig()
+    expect(config.environment).toBe("production")
+    expect(config.allowMockData).toBe(false)
+    expect(config.gracefulDegradation).toBe(false)
+  })
+
+  it("detects test environment", () => {
+    process.env.NODE_ENV = "test"
+    const config = getEnvironmentConfig()
+    expect(config.environment).toBe("test")
+    expect(config.allowMockData).toBe(false)
+    expect(config.gracefulDegradation).toBe(true)
+  })
+})
+
+describe("getEnvironmentVariable", () => {
+  it("returns variable value when set", () => {
+    process.env.TEST_VAR = "present"
+    const value = getEnvironmentVariable("TEST_VAR")
+    expect(value).toBe("present")
+  })
+
+  it("returns undefined for optional missing variable", () => {
+    delete (process.env as Record<string, string>).TEST_VAR
+    const value = getEnvironmentVariable("TEST_VAR")
+    expect(value).toBeUndefined()
+  })
+
+  it("throws for required missing variable", () => {
+    delete (process.env as Record<string, string>).TEST_VAR
+    expect(() => getEnvironmentVariable("TEST_VAR", true)).toThrow(
+      "Required environment variable TEST_VAR is not set"
+    )
+  })
+})
+
+describe("environment helpers", () => {
+  it("isDevelopment returns true in development", () => {
+    process.env.NODE_ENV = "development"
+    process.env.CLOUDFLARE_ENVIRONMENT = undefined as unknown as string
+    expect(isDevelopment()).toBe(true)
+    expect(isProduction()).toBe(false)
+  })
+
+  it("isProduction returns true in production", () => {
+    process.env.NODE_ENV = "production"
+    expect(isProduction()).toBe(true)
+    expect(isDevelopment()).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- add tests for environment helpers

## Testing
- `bun run test`

------
https://chatgpt.com/codex/tasks/task_e_6845c8f5ff748332b729aa3a89735295

## Summary by Sourcery

Add comprehensive unit tests for environment utility functions to validate configuration selection, variable retrieval, and environment checks

Tests:
- Test getEnvironmentConfig behavior in development, production, and test environments
- Test getEnvironmentVariable for optional and required variables
- Test isDevelopment and isProduction helper functions