### PR TITLE
Fix JWT secret mismatch detection

### DIFF
--- a/STATE.md
+++ b/STATE.md
@@ -111,3 +111,8 @@
 - **Redirect Testing**: ✅ WORKING (4/4 redirects now pass)
 
 **REMAINING GOAL**: Resolve JWT signature verification for admin tokens to achieve 35-40/40 tests passing.
+
+## NEW FIX
+
+- **✅ IMPLEMENTED**: Added warning log if JWT secret from Cloudflare environment differs from runtime config.
+- **✅ ADDED TEST**: `authorizeEndpoint` unit test ensures mismatch warning is triggered and token still verifies with Cloudflare secret.


### PR DESCRIPTION
## Summary
- log when Cloudflare env secret and runtime secret differ
- test authorizeEndpoint secret mismatch warning
- document fix in STATE.md

## Testing
- `bun run test`

------
https://chatgpt.com/codex/tasks/task_e_6845c8dd501c8332bb41f5a2ae45cc13

## Summary by Sourcery

Implement detection and warning for mismatched JWT secrets between Cloudflare environment and runtime config in endpoint authorization, add a unit test for this behavior, and update documentation accordingly.

Bug Fixes:
- Warn when the JWT secret from Cloudflare environment and runtime config mismatch during endpoint authorization

Enhancements:
- Prioritize Cloudflare Workers JWT secret over runtime config when available

Documentation:
- Update STATE.md to document the JWT secret mismatch warning

Tests:
- Add unit test to verify warning is logged on JWT secret mismatch in authorizeEndpoint