### PR TITLE
Add real-time dashboard via WebSockets

### DIFF
--- a/components/LiveMetrics.vue
+++ b/components/LiveMetrics.vue
@@ -1,0 +1,53 @@
+<template>
+  <UCard class="w-full">
+    <canvas ref="canvas" class="w-full h-64"></canvas>
+  </UCard>
+</template>
+
+<script setup lang="ts">
+import { onBeforeUnmount, onMounted, ref } from "vue"
+import { useRuntimeConfig } from "#imports"
+
+const canvas = ref<HTMLCanvasElement | null>(null)
+interface ChartInstance {
+  data: { labels: string[]; datasets: { data: number[] }[] }
+  update: (mode?: string) => void
+}
+let chart: ChartInstance | null = null
+let socket: WebSocket | null = null
+
+async function initChart() {
+  if (!canvas.value) return
+  const mod = await import("https://cdn.jsdelivr.net/npm/chart.js@4.4.9/dist/chart.umd.js")
+  const Chart = mod.default
+  chart = new Chart(canvas.value, {
+    type: "line",
+    data: { labels: [], datasets: [{ label: "Requests", data: [], borderColor: "#4ade80", fill: false }] },
+    options: { animation: false }
+  })
+}
+
+function updateChart(data: { ok: number; error: number; timestamp: number }) {
+  if (!chart) return
+  chart.data.labels.push(new Date(data.timestamp).toLocaleTimeString())
+  chart.data.datasets[0].data.push(data.ok)
+  if (chart.data.labels.length > 20) {
+    chart.data.labels.shift()
+    chart.data.datasets[0].data.shift()
+  }
+  chart.update("none")
+}
+
+onMounted(async () => {
+  await initChart()
+  const config = useRuntimeConfig()
+  const url = new URL(`${config.public.apiBaseUrl}/dashboard/live`, window.location.href)
+  url.protocol = url.protocol === "https:" ? "wss:" : "ws:"
+  socket = new WebSocket(url.toString())
+  socket.addEventListener("message", (e) => updateChart(JSON.parse(e.data)))
+})
+
+onBeforeUnmount(() => {
+  socket?.close()
+})
+</script>

--- a/pages/dashboard/index.vue
+++ b/pages/dashboard/index.vue
@@ -1,0 +1,21 @@
+<template>
+  <div class="min-h-screen p-4 bg-black text-white">
+    <h1 class="text-3xl font-bold mb-4">Live Dashboard</h1>
+    <LiveMetrics />
+  </div>
+</template>
+
+<script setup lang="ts">
+import LiveMetrics from "~/components/LiveMetrics.vue"
+
+useHead({
+  title: "Live Dashboard - dave.io",
+  meta: [{ name: "description", content: "Real-time metrics dashboard" }]
+})
+
+const { logPageVisit } = usePageLogging()
+
+onMounted(() => {
+  logPageVisit("/dashboard", { title: "live-dashboard" })
+})
+</script>

--- a/server/api/dashboard/live.ts
+++ b/server/api/dashboard/live.ts
@@ -1,0 +1,36 @@
+import { recordAPIErrorMetrics, recordAPIMetrics } from "~/server/middleware/metrics"
+import { getCloudflareEnv } from "~/server/utils/cloudflare"
+import { createApiError, isApiError, logRequest } from "~/server/utils/response"
+
+export default defineEventHandler(async (event) => {
+  const start = Date.now()
+  try {
+    const env = getCloudflareEnv(event)
+    // Require DO binding
+    if (!("DASHBOARD_WS" in env)) {
+      throw createApiError(503, "WebSocket service unavailable")
+    }
+    // biome-ignore lint/suspicious/noExplicitAny: dynamic env access
+    const wsNamespace = (env as any).DASHBOARD_WS as DurableObjectNamespace
+    const id = wsNamespace.idFromName("metrics")
+    const stub = wsNamespace.get(id)
+
+    // Forward request to Durable Object for WebSocket upgrade
+    const response = await stub.fetch(event.node.req as unknown as Request)
+
+    recordAPIMetrics(event, 101)
+    logRequest(event, "dashboard/live", "GET", 101, { duration: Date.now() - start })
+
+    return response
+  } catch (error: unknown) {
+    console.error("Live dashboard error:", error)
+    recordAPIErrorMetrics(event, error)
+    // biome-ignore lint/suspicious/noExplicitAny: isApiError ensures property
+    const status = isApiError(error) ? (error as any).statusCode || 500 : 500
+    logRequest(event, "dashboard/live", "GET", status, { error: String(error) })
+    if (isApiError(error)) {
+      throw error
+    }
+    throw createApiError(500, "Failed to connect to dashboard")
+  }
+})

--- a/server/socket/dashboard.ts
+++ b/server/socket/dashboard.ts
@@ -1,0 +1,79 @@
+import { DurableObject } from "cloudflare:workers"
+
+interface Env {
+  DATA: KVNamespace
+}
+
+export class DashboardWebSocket extends DurableObject<Env> {
+  private connections: Set<WebSocket>
+  private intervalId: number | undefined
+
+  constructor(ctx: DurableObjectState, env: Env) {
+    super(ctx, env)
+    this.connections = new Set()
+  }
+
+  override async fetch(request: Request): Promise<Response> {
+    if (request.headers.get("Upgrade")?.toLowerCase() !== "websocket") {
+      return new Response("Expected WebSocket", { status: 400 })
+    }
+
+    const pair = new WebSocketPair()
+    const [client, server] = Object.values(pair) as [WebSocket, WebSocket]
+
+    this.ctx.acceptWebSocket(server)
+    this.connections.add(server)
+
+    if (!this.intervalId) {
+      // Broadcast metrics every 5 seconds while connections are active
+      this.intervalId = setInterval(() => {
+        this.broadcastMetrics().catch((err) => {
+          console.error("Broadcast error", err)
+        })
+      }, 5000) as unknown as number
+    }
+
+    return new Response(null, { status: 101, webSocket: client })
+  }
+
+  private async broadcastMetrics(): Promise<void> {
+    try {
+      const [okStr, errorStr] = await Promise.all([this.env.DATA.get("metrics:ok"), this.env.DATA.get("metrics:error")])
+
+      const payload = JSON.stringify({
+        ok: okStr ? Number.parseInt(okStr, 10) : 0,
+        error: errorStr ? Number.parseInt(errorStr, 10) : 0,
+        timestamp: Date.now()
+      })
+
+      for (const ws of this.connections) {
+        try {
+          ws.send(payload)
+        } catch (error) {
+          console.error("Send failed", error)
+          this.connections.delete(ws)
+        }
+      }
+
+      if (this.connections.size === 0 && this.intervalId) {
+        clearInterval(this.intervalId)
+        this.intervalId = undefined
+      }
+    } catch (error) {
+      console.error("Metric retrieval failed", error)
+    }
+  }
+
+  override async webSocketMessage(_ws: WebSocket, _message: string | ArrayBuffer): Promise<void> {
+    // No client messages expected
+  }
+
+  override async webSocketClose(ws: WebSocket): Promise<void> {
+    this.connections.delete(ws)
+  }
+
+  override async webSocketError(ws: WebSocket, error: unknown): Promise<void> {
+    console.error("WebSocket error", error)
+    ws.close(1011, "WebSocket error")
+  }
+}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -25,6 +25,20 @@
       "database_id": "106894e2-1f5c-4979-a777-0b45febbb993"
     }
   ],
+  "durable_objects": {
+    "bindings": [
+      {
+        "name": "DASHBOARD_WS",
+        "class_name": "DashboardWebSocket"
+      }
+    ]
+  },
+  "migrations": [
+    {
+      "tag": "v1",
+      "new_classes": ["DashboardWebSocket"]
+    }
+  ],
   "routes": [
     {
       "pattern": "next.dave.io",


### PR DESCRIPTION
## Summary
- add Durable Object to broadcast metrics updates
- expose live WebSocket endpoint
- create LiveMetrics component and dashboard page
- register DO binding in wrangler config

## Testing
- `bun run lint` *(fails: TypeError: fetch failed)*
- `bun run typecheck`
- `bun run test`
- `bun run test:api` *(fails: 20 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_6845f5588144833287e7ac2c764e0e12

## Summary by Sourcery

Implement a real-time metrics dashboard powered by Cloudflare Durable Objects and WebSockets

New Features:
- Introduce DashboardWebSocket Durable Object to broadcast metrics at regular intervals
- Expose a /dashboard/live API endpoint to upgrade HTTP connections to WebSocket streams
- Add LiveMetrics Vue component that displays incoming metrics via Chart.js
- Create a dashboard page to host the live metrics component and log page visits

Enhancements:
- Register DASHBOARD_WS binding in the Wrangler configuration