### PR TITLE
Make image optimisation public

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,12 +92,11 @@ Nuxt 3 + Cloudflare Workers REST API. JWT auth, Zod validation, comprehensive te
 
 ## Key Endpoints
 
-**Public**: `/api/internal/health|ping|worker`, `/go/{slug}`
+**Public**: `/api/internal/health|ping|worker`, `/api/images/optimise`, `/go/{slug}`
 **Protected** (require JWT + scope):
 - `/api/internal/auth` - Token validation (any token)
 - `/api/internal/metrics` - API metrics (`api:metrics`+)
 - `/api/ai/alt` - Alt-text generation (`ai:alt`+)
-- `/api/images/optimise` - Image processing (`api:images`+)
 - `/api/tokens/{uuid}/*` - Token management (`api:tokens`+)
 
 ## Breaking Changes
@@ -268,7 +267,7 @@ curl -H "Authorization: Bearer <token>" "http://localhost:3000/api/ai/alt?url=ht
 curl -X POST -H "Authorization: Bearer <token>" -d '{"image": "<base64>"}' http://localhost:3000/api/ai/alt
 
 # Image optimisation
-curl -X POST -H "Authorization: Bearer <token>" -d '{"image": "<base64>", "quality": 80}' http://localhost:3000/api/images/optimise
+curl -X POST -d '{"image": "<base64>", "quality": 80}' http://localhost:3000/api/images/optimise
 ```
 
 ## CLI Usage
@@ -293,7 +292,7 @@ bun try internal health              # Test system health (no auth required)
 bun try internal auth                # Validate JWT token
 bun try internal metrics --format yaml  # Get metrics in YAML format
 bun try ai alt-url "https://example.com/image.jpg"  # Generate alt-text from URL
-bun try images optimize-file "./image.png" --quality 75  # Optimize local image
+bun try images optimize-file "./image.png" --quality 75  # Optimize local image (public)
 bun try tokens info <uuid>           # Get token information
 bun try dashboard data "hacker-news" # Get dashboard data
 bun try --remote internal health     # Test against production [default]
@@ -342,7 +341,7 @@ bun run test:api --url https://your-worker.workers.dev
 - **Processing**: Hybrid API upload + binding transformations
 - **Caching**: Content-based deduplication using BLAKE3 hashing
 - **AI Integration**: Direct function invocation for alt-text processing
-- **Limits**: 4MB post-decode, requires `api:images` scope
+- **Limits**: 4MB post-decode, no authentication required
 - **Benefits**: No external dependencies, global edge network, automatic optimization
 
 ## Linting Guidelines

--- a/bin/endpoints/images.ts
+++ b/bin/endpoints/images.ts
@@ -15,17 +15,9 @@ interface ImageOptimiseResponse {
 
 /**
  * Adapter for image optimization operations (/api/images/*)
- * Requires 'api:images' scope or higher for authentication
+ * Public endpoint - authentication optional
  */
 export class ImagesAdapter extends BaseAdapter {
-  /**
-   * Create a new images adapter instance
-   * @param config Configuration for the adapter
-   */
-  constructor(config: RequestConfig) {
-    super(config)
-  }
-
   /**
    * Optimize an image from a URL
    * @param imageUrl URL of the image to optimize

--- a/bin/try.ts
+++ b/bin/try.ts
@@ -209,7 +209,6 @@ imagesCommand
   .action(async (imageUrl, cmdOptions, command) => {
     const options = command.parent?.parent?.opts() as GlobalOptions
     const config = createConfig(options)
-    validateToken(config, "api:images")
 
     const adapter = new ImagesAdapter(config)
     const result = await withSpinner(
@@ -228,7 +227,6 @@ imagesCommand
   .action(async (filePath, cmdOptions, command) => {
     const options = command.parent?.parent?.opts() as GlobalOptions
     const config = createConfig(options)
-    validateToken(config, "api:images")
 
     const adapter = new ImagesAdapter(config)
     const result = await withSpinner(
@@ -454,7 +452,6 @@ Environment Variables:
 
 Token Creation:
   ${chalk.green("bun jwt create --sub 'ai:alt' --description 'AI testing'")}
-  ${chalk.green("bun jwt create --sub 'api:images' --description 'Image testing'")}
   ${chalk.green("bun jwt create --sub 'api:metrics' --description 'Metrics access'")}
 `
 )

--- a/server/api/images/optimise.ts
+++ b/server/api/images/optimise.ts
@@ -1,5 +1,4 @@
 import { recordAPIErrorMetrics, recordAPIMetrics } from "~/server/middleware/metrics"
-import { requireAPIAuth } from "~/server/utils/auth-helpers"
 import { getCloudflareEnv } from "~/server/utils/cloudflare"
 import { processImageWithCloudflareImages } from "~/server/utils/cloudflare-images"
 import { createApiError, createApiResponse, isApiError, logRequest } from "~/server/utils/response"
@@ -13,9 +12,6 @@ export default defineEventHandler(async (event) => {
   const method = getMethod(event)
 
   try {
-    // Require API authentication for image optimisation
-    const auth = await requireAPIAuth(event, "images")
-
     const env = getCloudflareEnv(event)
 
     let imageBuffer: Buffer
@@ -69,7 +65,6 @@ export default defineEventHandler(async (event) => {
 
     // Log successful request
     logRequest(event, "images/optimise", method, 200, {
-      user: auth.payload?.sub || "anonymous",
       originalSize: result.originalSize,
       optimisedSize: result.optimisedSize,
       compressionRatio: Math.round((1 - result.optimisedSize / result.originalSize) * 100),

--- a/test/try-adapters.test.ts
+++ b/test/try-adapters.test.ts
@@ -11,6 +11,7 @@ import {
 } from "../bin/try"
 
 // Mock fetch globally
+// biome-ignore lint/suspicious/noExplicitAny: mock function type
 const mockFetch = vi.fn() as any
 global.fetch = mockFetch
 
@@ -117,6 +118,7 @@ describe("BaseAdapter", () => {
         }
       }
       const dryRunAdapter = new TestAdapter(dryRunConfig)
+      // biome-ignore lint/suspicious/noExplicitAny: cast for test access
       const result = await (dryRunAdapter as any).testMethod()
 
       expect(result.success).toBe(true)
@@ -451,6 +453,23 @@ describe("ImagesAdapter", () => {
         body: JSON.stringify({ image: "base64data", quality: 75 })
       })
     )
+  })
+
+  it("should omit token when not provided", async () => {
+    const noTokenConfig = { ...config, token: undefined }
+    adapter = new ImagesAdapter(noTokenConfig)
+
+    const mockResponse = {
+      ok: true,
+      status: 200,
+      json: async () => ({ success: true })
+    }
+    mockFetch.mockResolvedValueOnce(mockResponse)
+
+    await adapter.optimiseFromUrl("https://example.com/test.png")
+
+    const calledUrl = mockFetch.mock.calls[0][0] as string
+    expect(calledUrl).not.toContain("token=")
   })
 })
 


### PR DESCRIPTION
## Summary
- remove auth requirement from images optimise endpoint
- update CLI scripts to match new behaviour
- document the endpoint as public
- cover adapter behaviour in tests

## Testing
- `bun run lint:check` *(failed: TypeError: fetch failed)*
- `bun run lint:types`
- `bun run test` *(failed: Failed to resolve import "boxen" from bin/try.ts)*
- `bun run check` *(failed: process interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68485b86be34833287c1ad9ac99f06e1