### PR TITLE
Fix OpenAPI docs for AI tickets

### DIFF
--- a/bin/openapi.ts
+++ b/bin/openapi.ts
@@ -149,6 +149,107 @@ registry.registerPath({
 
 registry.registerPath({
   method: "post",
+  path: "/api/ai/tickets/title",
+  tags: ["AI"],
+  summary: "Generate ticket title",
+  description: "Generate a concise title for a Linear ticket",
+  requestBody: {
+    required: true,
+    content: {
+      "application/json": {
+        schema: schemas.AiTicketTitleRequestSchema
+      }
+    }
+  },
+  responses: {
+    200: {
+      description: "Title generated successfully",
+      content: {
+        "application/json": {
+          schema: schemas.AiTicketTitleResponseSchema
+        }
+      }
+    },
+    400: {
+      description: "Invalid request",
+      content: {
+        "application/json": {
+          schema: schemas.ApiErrorResponseSchema
+        }
+      }
+    }
+  }
+})
+
+registry.registerPath({
+  method: "post",
+  path: "/api/ai/tickets/description",
+  tags: ["AI"],
+  summary: "Generate ticket description",
+  description: "Generate a detailed ticket description from a title",
+  requestBody: {
+    required: true,
+    content: {
+      "application/json": {
+        schema: schemas.AiTicketDescriptionRequestSchema
+      }
+    }
+  },
+  responses: {
+    200: {
+      description: "Description generated successfully",
+      content: {
+        "application/json": {
+          schema: schemas.AiTicketDescriptionResponseSchema
+        }
+      }
+    },
+    400: {
+      description: "Invalid request",
+      content: {
+        "application/json": {
+          schema: schemas.ApiErrorResponseSchema
+        }
+      }
+    }
+  }
+})
+
+registry.registerPath({
+  method: "post",
+  path: "/api/ai/tickets/enrich",
+  tags: ["AI"],
+  summary: "Enrich ticket description",
+  description: "Enrich an existing ticket description with additional context",
+  requestBody: {
+    required: true,
+    content: {
+      "application/json": {
+        schema: schemas.AiTicketEnrichRequestSchema
+      }
+    }
+  },
+  responses: {
+    200: {
+      description: "Ticket description enriched successfully",
+      content: {
+        "application/json": {
+          schema: schemas.AiTicketEnrichResponseSchema
+        }
+      }
+    },
+    400: {
+      description: "Invalid request",
+      content: {
+        "application/json": {
+          schema: schemas.ApiErrorResponseSchema
+        }
+      }
+    }
+  }
+})
+registry.registerPath({
+  method: "post",
   path: "/api/images/optimise",
   tags: ["Images"],
   summary: "Optimize image",

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -2361,6 +2361,393 @@
         }
       }
     },
+    "/api/ai/tickets/title": {
+      "post": {
+        "tags": ["AI"],
+        "summary": "Generate ticket title",
+        "description": "Generate a concise title for a Linear ticket",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "_def": {
+                  "schema": {
+                    "_def": {
+                      "unknownKeys": "strip",
+                      "catchall": {
+                        "_def": {
+                          "typeName": "ZodNever"
+                        },
+                        "~standard": {
+                          "version": 1,
+                          "vendor": "zod"
+                        }
+                      },
+                      "typeName": "ZodObject"
+                    },
+                    "~standard": {
+                      "version": 1,
+                      "vendor": "zod"
+                    },
+                    "_cached": null
+                  },
+                  "typeName": "ZodEffects",
+                  "effect": {
+                    "type": "refinement"
+                  }
+                },
+                "~standard": {
+                  "version": 1,
+                  "vendor": "zod"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Title generated successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "enum": [true]
+                    },
+                    "result": {
+                      "type": "object",
+                      "properties": {
+                        "title": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["title"]
+                    },
+                    "status": {
+                      "type": ["object", "null"],
+                      "properties": {
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["message"]
+                    },
+                    "error": {
+                      "type": "null"
+                    },
+                    "timestamp": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["ok", "result", "status", "error", "timestamp"]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "enum": [false]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": ["object", "null"],
+                      "properties": {
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["message"]
+                    },
+                    "details": {},
+                    "meta": {
+                      "type": "object",
+                      "properties": {
+                        "request_id": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "timestamp": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["ok", "error", "message", "status", "timestamp"]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/ai/tickets/description": {
+      "post": {
+        "tags": ["AI"],
+        "summary": "Generate ticket description",
+        "description": "Generate a detailed ticket description from a title",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "_def": {
+                  "unknownKeys": "strip",
+                  "catchall": {
+                    "_def": {
+                      "typeName": "ZodNever"
+                    },
+                    "~standard": {
+                      "version": 1,
+                      "vendor": "zod"
+                    }
+                  },
+                  "typeName": "ZodObject"
+                },
+                "~standard": {
+                  "version": 1,
+                  "vendor": "zod"
+                },
+                "_cached": null
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Description generated successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "enum": [true]
+                    },
+                    "result": {
+                      "type": "object",
+                      "properties": {
+                        "description": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["description"]
+                    },
+                    "status": {
+                      "type": ["object", "null"],
+                      "properties": {
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["message"]
+                    },
+                    "error": {
+                      "type": "null"
+                    },
+                    "timestamp": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["ok", "result", "status", "error", "timestamp"]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "enum": [false]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": ["object", "null"],
+                      "properties": {
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["message"]
+                    },
+                    "details": {},
+                    "meta": {
+                      "type": "object",
+                      "properties": {
+                        "request_id": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "timestamp": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["ok", "error", "message", "status", "timestamp"]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/ai/tickets/enrich": {
+      "post": {
+        "tags": ["AI"],
+        "summary": "Enrich ticket description",
+        "description": "Enrich an existing ticket description with additional context",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "_def": {
+                  "schema": {
+                    "_def": {
+                      "unknownKeys": "strip",
+                      "catchall": {
+                        "_def": {
+                          "typeName": "ZodNever"
+                        },
+                        "~standard": {
+                          "version": 1,
+                          "vendor": "zod"
+                        }
+                      },
+                      "typeName": "ZodObject"
+                    },
+                    "~standard": {
+                      "version": 1,
+                      "vendor": "zod"
+                    },
+                    "_cached": null
+                  },
+                  "typeName": "ZodEffects",
+                  "effect": {
+                    "type": "refinement"
+                  }
+                },
+                "~standard": {
+                  "version": 1,
+                  "vendor": "zod"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Ticket description enriched successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "enum": [true]
+                    },
+                    "result": {
+                      "type": "object",
+                      "properties": {
+                        "description": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["description"]
+                    },
+                    "status": {
+                      "type": ["object", "null"],
+                      "properties": {
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["message"]
+                    },
+                    "error": {
+                      "type": "null"
+                    },
+                    "timestamp": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["ok", "result", "status", "error", "timestamp"]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "enum": [false]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": ["object", "null"],
+                      "properties": {
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["message"]
+                    },
+                    "details": {},
+                    "meta": {
+                      "type": "object",
+                      "properties": {
+                        "request_id": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "timestamp": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["ok", "error", "message", "status", "timestamp"]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/images/optimise": {
       "post": {
         "tags": ["Images"],

--- a/test/openapi.test.ts
+++ b/test/openapi.test.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from "node:fs"
+import { describe, expect, it } from "vitest"
+
+const spec = JSON.parse(readFileSync("public/openapi.json", "utf8"))
+
+describe("OpenAPI spec", () => {
+  it("includes AI ticket endpoints", () => {
+    const paths = Object.keys(spec.paths)
+    expect(paths).toContain("/api/ai/tickets/title")
+    expect(paths).toContain("/api/ai/tickets/description")
+    expect(paths).toContain("/api/ai/tickets/enrich")
+  })
+})


### PR DESCRIPTION
## Summary
- add OpenAPI definitions for `/api/ai/tickets` endpoints
- regenerate OpenAPI spec
- test that the spec exposes all AI ticket paths

## Testing
- `bun run test`
- `bun run build` *(fails: could not fetch fonts)*
- `bun run lint:biome` *(fails: lint errors in repo)*
- `bun run lint:trunk` *(fails: fetch failed)*
- `bun run lint:types` *(fails: TypeScript errors in repo)*
- `bun run check` *(failed during dependency install)*

------
https://chatgpt.com/codex/tasks/task_e_684a3c214dfc83328eb87397ee13696d

## Summary by Sourcery

Add OpenAPI documentation for AI ticket endpoints and verify their inclusion in the spec

New Features:
- Add OpenAPI definitions for AI ticket endpoints: generate title, description, and enrichment

Enhancements:
- Regenerate OpenAPI spec to include new AI ticket paths

Tests:
- Add test to confirm OpenAPI spec exposes AI ticket endpoints (/api/ai/tickets/title, /description, /enrich)