### PR TITLE
Add form upload support for AI alt endpoint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,7 @@
 - **Endpoints**: Merged `/api/internal/*` → `/api/ping`
 - **Auth**: `--auth` auto-generates tokens, `--token <JWT>` for provided tokens
 - **Dev**: No reset cycle, starts in seconds, `test:all` for full suite
-- **AI Alt**: Raw base64 POST, 4MB limit with auto-optimization
+- **AI Alt**: Raw base64 POST or multipart form upload, 4MB limit with auto-optimization
 - **Images**: Cloudflare Images service, BLAKE3 IDs, global CDN
 - **KV**: Individual keys vs JSON blob, hierarchical colon-separated, YAML anchors
 
@@ -92,9 +92,11 @@ bun install && bun run dev  # Starts in ~3s
 
 ```bash
 curl http://localhost:3000/api/ping  # Status
-curl -H "Authorization: Bearer <token>" "/api/ai/alt?url=https://example.com/image.jpg"  # Alt-text
+curl -H "Authorization: Bearer <token>" "/api/ai/alt?url=https://example.com/image.jpg"  # Alt-text via URL
+curl -X POST -F "image=@path/to/image.jpg" -H "Authorization: Bearer <token>" http://localhost:3000/api/ai/alt  # Alt-text via form
 curl -X POST -d '{"description": "Fix bug"}' /api/ai/tickets/title  # AI title (public)
-curl -X POST -d '{"image": "<base64>", "quality": 80}' /api/images/optimise  # Optimize
+curl -X POST -d '{"image": "<base64>", "quality": 80}' /api/images/optimise  # Optimize via JSON
+curl -F "image=@path/to/image.jpg" -F "quality=80" http://localhost:3000/api/images/optimise  # Optimize via form
 ```
 
 ## CLI Usage

--- a/test/form-image-validation.test.ts
+++ b/test/form-image-validation.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest"
+import { validateFormDataImage } from "~/server/utils/validation"
+
+const smallPngBase64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M/wHwAE/AO/lZy6hAAAAABJRU5ErkJggg=="
+
+const textBuffer = Buffer.from("hello world")
+
+describe("validateFormDataImage", () => {
+  it("accepts valid image file", async () => {
+    const buf = Buffer.from(smallPngBase64, "base64")
+    const file = new File([buf], "test.png", { type: "image/png" })
+    const result = await validateFormDataImage(file)
+    expect(result).toBeInstanceOf(Buffer)
+    expect(result.length).toBeGreaterThan(0)
+  })
+
+  it("rejects non-image file", async () => {
+    const file = new File([textBuffer], "text.txt", { type: "text/plain" })
+    await expect(validateFormDataImage(file)).rejects.toThrow()
+  })
+})

--- a/test/parse-image-upload.test.ts
+++ b/test/parse-image-upload.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+vi.mock("h3", async () => {
+  const actual = await vi.importActual<typeof import("h3")>("h3")
+  return {
+    ...actual,
+    getHeader: vi.fn(),
+    readBody: vi.fn(),
+    readFormData: vi.fn()
+  }
+})
+
+import { getHeader, readBody, readFormData } from "h3"
+import type { H3Event } from "h3"
+import { parseImageUpload } from "~/server/utils/validation"
+
+const smallPngBase64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M/wHwAE/AO/lZy6hAAAAABJRU5ErkJggg=="
+
+function mockEvent(headers: Record<string, string>): H3Event {
+  return { node: { req: { headers } } } as unknown as H3Event
+}
+
+describe("parseImageUpload", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("parses base64 JSON body", async () => {
+    const event = mockEvent({ "content-type": "application/json" })
+    vi.mocked(getHeader).mockImplementation((e: H3Event, n: string) => (e as any).node.req.headers[n])
+    vi.mocked(readBody).mockResolvedValue({ image: smallPngBase64 })
+    const result = await parseImageUpload(event)
+    expect(result.buffer).toBeInstanceOf(Buffer)
+    expect(result.source).toBe("uploaded-file")
+  })
+
+  it("parses multipart form data", async () => {
+    const event = mockEvent({ "content-type": "multipart/form-data" })
+    vi.mocked(getHeader).mockImplementation((e: H3Event, n: string) => (e as any).node.req.headers[n])
+    const buf = Buffer.from(smallPngBase64, "base64")
+    const file = new File([buf], "test.png", { type: "image/png" })
+    const form = new FormData()
+    form.set("image", file)
+    vi.mocked(readFormData).mockResolvedValue(form)
+    const result = await parseImageUpload(event)
+    expect(result.buffer).toBeInstanceOf(Buffer)
+    expect(result.source).toBe("test.png")
+  })
+})


### PR DESCRIPTION
## Summary
- support multipart form data for `/api/ai/alt` like `/api/images/optimise`
- consolidate image upload handling in `parseImageUpload`
- document new alt endpoint usage
- add unit tests for `parseImageUpload`

## Testing
- `bun run build` *(failed: network issue during bun install)*
- `bun run lint:biome` *(failed: script not found)*
- `bun run lint:trunk` *(failed: missing system utilities)*
- `bun run lint:types` *(failed: tsc not found)*
- `bun run test` *(failed: vitest not found)*
- `bun run check` *(failed: missing run-s script)*

------
https://chatgpt.com/codex/tasks/task_e_684a3c544b4c8332a5f44d7c6378cfb9